### PR TITLE
widgets: Prevent UB in send event due to type promotion

### DIFF
--- a/include/widgets/gp_widget_event.h
+++ b/include/widgets/gp_widget_event.h
@@ -145,7 +145,7 @@ static inline int gp_widget_send_event(gp_widget *self,
  * @return The return value from application event handler.
  */
 static inline int gp_widget_send_widget_event(gp_widget *self,
-				              uint16_t sub_type,
+				              unsigned int sub_type,
 				              ...)
 {
 	if (!self->on_event)

--- a/libs/core/gp_pixel.c
+++ b/libs/core/gp_pixel.c
@@ -25,8 +25,8 @@ get_channel(const gp_pixel_type_desc *desc, const char *name)
 
 static int match(const gp_pixel_channel *channel, gp_pixel mask)
 {
-	if (channel == NULL) {
-		GP_DEBUG(3, "%s gen %08x pass %08x", channel->name, 0, mask);
+	if (!channel) {
+		GP_DEBUG(3, "NULL gen %08x pass %08x", 0, mask);
 		return !mask;
 	}
 


### PR DESCRIPTION
Fix some complaints by Clang analyzers.