### PR TITLE
configure: Allow defining NO_CONFIG to skip including config.h

### DIFF
--- a/libs/backends/gp_aalib.c
+++ b/libs/backends/gp_aalib.c
@@ -10,7 +10,9 @@
 #include <backends/gp_aalib.h>
 #include <input/gp_input.h>
 
+#ifndef NO_CONFIG
 #include "../config.h"
+#endif
 
 #ifdef HAVE_AALIB
 

--- a/libs/backends/gp_aalib.c
+++ b/libs/backends/gp_aalib.c
@@ -10,7 +10,7 @@
 #include <backends/gp_aalib.h>
 #include <input/gp_input.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../config.h"
 #endif
 

--- a/libs/backends/gp_input_driver_sdl.c
+++ b/libs/backends/gp_input_driver_sdl.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2013 Cyril Hrubis <metan@ucw.cz>
  */
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/backends/gp_input_driver_sdl.c
+++ b/libs/backends/gp_input_driver_sdl.c
@@ -3,7 +3,9 @@
  * Copyright (C) 2009-2013 Cyril Hrubis <metan@ucw.cz>
  */
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #ifdef HAVE_LIBSDL
 

--- a/libs/backends/gp_sdl.c
+++ b/libs/backends/gp_sdl.c
@@ -6,7 +6,7 @@
  * Copyright (C) 2009-2013 Cyril Hrubis <metan@ucw.cz>
  */
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/backends/gp_sdl.c
+++ b/libs/backends/gp_sdl.c
@@ -6,7 +6,9 @@
  * Copyright (C) 2009-2013 Cyril Hrubis <metan@ucw.cz>
  */
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #include <core/gp_debug.h>
 

--- a/libs/backends/gp_x11.c
+++ b/libs/backends/gp_x11.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <errno.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/backends/gp_x11.c
+++ b/libs/backends/gp_x11.c
@@ -6,7 +6,9 @@
 #include <string.h>
 #include <errno.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #include <core/gp_debug.h>
 #include "core/gp_common.h"

--- a/libs/backends/gp_xcb.c
+++ b/libs/backends/gp_xcb.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2019 Cyril Hrubis <metan@ucw.cz>
  */
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/backends/gp_xcb.c
+++ b/libs/backends/gp_xcb.c
@@ -3,7 +3,9 @@
  * Copyright (C) 2009-2019 Cyril Hrubis <metan@ucw.cz>
  */
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #include <core/gp_debug.h>
 #include "core/gp_common.h"

--- a/libs/core/gp_common.c
+++ b/libs/core/gp_common.c
@@ -6,7 +6,7 @@
 
 #define _GNU_SOURCE
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../config.h"
 #endif
 

--- a/libs/core/gp_common.c
+++ b/libs/core/gp_common.c
@@ -6,7 +6,9 @@
 
 #define _GNU_SOURCE
 
+#ifndef NO_CONFIG
 #include "../config.h"
+#endif
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/libs/grabbers/gp_v4l2.c
+++ b/libs/grabbers/gp_v4l2.c
@@ -23,7 +23,7 @@
 
 #include <core/gp_debug.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/grabbers/gp_v4l2.c
+++ b/libs/grabbers/gp_v4l2.c
@@ -23,7 +23,9 @@
 
 #include <core/gp_debug.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #ifdef HAVE_V4L2
 

--- a/libs/loaders/gp_gif.c
+++ b/libs/loaders/gp_gif.c
@@ -15,7 +15,10 @@
 #include <errno.h>
 #include <string.h>
 
+
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 #include <core/gp_pixel.h>
 #include <core/gp_get_put_pixel.gen.h>
 #include "core/gp_fill.h"

--- a/libs/loaders/gp_gif.c
+++ b/libs/loaders/gp_gif.c
@@ -16,7 +16,7 @@
 #include <string.h>
 
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 #include <core/gp_pixel.h>

--- a/libs/loaders/gp_io_zlib.c
+++ b/libs/loaders/gp_io_zlib.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2014 Cyril Hrubis <metan@ucw.cz>
  */
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/loaders/gp_io_zlib.c
+++ b/libs/loaders/gp_io_zlib.c
@@ -3,7 +3,9 @@
  * Copyright (C) 2009-2014 Cyril Hrubis <metan@ucw.cz>
  */
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #include <errno.h>
 #include <stdint.h>

--- a/libs/loaders/gp_jp2.c
+++ b/libs/loaders/gp_jp2.c
@@ -13,7 +13,9 @@
 #include <string.h>
 #include <stdio.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 #include <core/gp_debug.h>
 #include <core/gp_get_put_pixel.h>
 

--- a/libs/loaders/gp_jp2.c
+++ b/libs/loaders/gp_jp2.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 #include <core/gp_debug.h>

--- a/libs/loaders/gp_jpg.c
+++ b/libs/loaders/gp_jpg.c
@@ -17,7 +17,7 @@
 #include <stdio.h>
 #include <setjmp.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 #include <core/gp_debug.h>

--- a/libs/loaders/gp_jpg.c
+++ b/libs/loaders/gp_jpg.c
@@ -17,7 +17,9 @@
 #include <stdio.h>
 #include <setjmp.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 #include <core/gp_debug.h>
 
 #include <loaders/gp_exif.h>

--- a/libs/loaders/gp_png.c
+++ b/libs/loaders/gp_png.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 #include <core/gp_byte_order.h>

--- a/libs/loaders/gp_png.c
+++ b/libs/loaders/gp_png.c
@@ -15,7 +15,9 @@
 #include <errno.h>
 #include <string.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 #include <core/gp_byte_order.h>
 #include <core/gp_debug.h>
 #include <core/gp_gamma_correction.h>

--- a/libs/loaders/gp_rar.c
+++ b/libs/loaders/gp_rar.c
@@ -6,7 +6,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/loaders/gp_rar.c
+++ b/libs/loaders/gp_rar.c
@@ -6,7 +6,9 @@
 #include <errno.h>
 #include <string.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #ifdef HAVE_LIBARCHIVE
 # include <archive.h>

--- a/libs/loaders/gp_tiff.c
+++ b/libs/loaders/gp_tiff.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/loaders/gp_tiff.c
+++ b/libs/loaders/gp_tiff.c
@@ -15,7 +15,9 @@
 #include <errno.h>
 #include <string.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #include <core/gp_pixel.h>
 #include <core/gp_get_put_pixel.h>

--- a/libs/loaders/gp_webp.c
+++ b/libs/loaders/gp_webp.c
@@ -12,7 +12,9 @@
 #include <errno.h>
 #include <string.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 #include <core/gp_debug.h>
 #include <core/gp_get_put_pixel.h>
 

--- a/libs/loaders/gp_webp.c
+++ b/libs/loaders/gp_webp.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <string.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 #include <core/gp_debug.h>

--- a/libs/loaders/gp_zip.c
+++ b/libs/loaders/gp_zip.c
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 

--- a/libs/loaders/gp_zip.c
+++ b/libs/loaders/gp_zip.c
@@ -9,7 +9,9 @@
 #include <stdint.h>
 #include <inttypes.h>
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 
 #ifdef HAVE_ZLIB
 

--- a/libs/text/gp_free_type.c
+++ b/libs/text/gp_free_type.c
@@ -3,7 +3,9 @@
  * Copyright (C) 2009-2012 Cyril Hrubis <metan@ucw.cz>
  */
 
+#ifndef NO_CONFIG
 #include "../../config.h"
+#endif
 #include <core/gp_debug.h>
 #include <text/gp_font.h>
 

--- a/libs/text/gp_free_type.c
+++ b/libs/text/gp_free_type.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2009-2012 Cyril Hrubis <metan@ucw.cz>
  */
 
-#ifndef NO_CONFIG
+#ifndef GFXPRIM_NO_CONFIG
 #include "../../config.h"
 #endif
 #include <core/gp_debug.h>


### PR DESCRIPTION
This change introduces a NO_CONFIG define, which when used, will omit the inclusion of `config.h`. This will allow compilations to select their compilation configuration based on definitions through the compiler rather than in a config.h file.

Add `-DNO_CONFIG -DHAVE_LIBSDL`, etc, and you're able to customize the build without having to rebuild the file.