### PR TITLE
core: threads: Fix include gp_common.h

### DIFF
--- a/libs/core/gp_threads.c
+++ b/libs/core/gp_threads.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 
-#include "gp_common.h"
+#include <core/gp_common.h>
 #include <core/gp_debug.h>
 
 #include <core/gp_threads.h>


### PR DESCRIPTION
The core directory wasn't included in the include paths, so adopting the same include pattern as the other <core> includes fixes this.