### PR TITLE
grabbers: v4l2: Fix grabbers when no HAVE_V4L2

### DIFF
--- a/libs/grabbers/gp_v4l2.c
+++ b/libs/grabbers/gp_v4l2.c
@@ -19,8 +19,8 @@
 
 #include <stdint.h>
 
-#include "core/gp_pixmap.h"
-
+#include <core/gp_pixmap.h>
+#include <grabbers/gp_grabber.h>
 #include <core/gp_debug.h>
 
 #include "../../config.h"
@@ -29,7 +29,6 @@
 
 #include <linux/videodev2.h>
 
-#include <grabbers/gp_grabber.h>
 #include <grabbers/gp_v4l2.h>
 
 struct v4l2_priv {


### PR DESCRIPTION
When missing HAVE_V4L2, `gb_grabber` was undefined from the below `#else` statement. This moves the gb_grabber.h include above HAVE_V4L2 so that it is defined.