### PR TITLE
widgets: date_time: Fix include

### DIFF
--- a/libs/widgets/gp_date_time.c
+++ b/libs/widgets/gp_date_time.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <gp_date_time.h>
+#include <widgets/gp_date_time.h>
 
 static const char *const months[] = {
 	"Jan",


### PR DESCRIPTION
The widgets directory isn't in the include paths, so prepending widgets fixes this.