### PR TITLE
widgets: Fix include widget headers

### DIFF
--- a/libs/widgets/gp_date_time.c
+++ b/libs/widgets/gp_date_time.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#include <gp_date_time.h>
+#include <widgets/gp_date_time.h>
 
 static const char *const months[] = {
 	"Jan",

--- a/libs/widgets/gp_dir_cache.c
+++ b/libs/widgets/gp_dir_cache.c
@@ -19,7 +19,7 @@
 
 #include <core/gp_debug.h>
 #include <utils/gp_block_alloc.h>
-#include <gp_dir_cache.h>
+#include <widgets/gp_dir_cache.h>
 
 static gp_dir_entry *new_entry(gp_dir_cache *self, size_t size,
                                const char *name, mode_t mode, time_t mtime)

--- a/libs/widgets/gp_file_size.c
+++ b/libs/widgets/gp_file_size.c
@@ -7,7 +7,7 @@
  */
 
 #include <stdio.h>
-#include <gp_file_size.h>
+#include <widgets/gp_file_size.h>
 
 const char *gp_str_file_size(char *buf, size_t buf_len, size_t size)
 {

--- a/libs/widgets/gp_key_repeat_timer.c
+++ b/libs/widgets/gp_key_repeat_timer.c
@@ -19,7 +19,7 @@
 #include <input/gp_timer.h>
 #include <input/gp_event_queue.h>
 #include <input/gp_time_stamp.h>
-#include <gp_widget_timer.h>
+#include <widgets/gp_widget_timer.h>
 
 static struct gp_event_queue *event_queue;
 static gp_timer **timer_queue;

--- a/libs/widgets/gp_markup_parser.c
+++ b/libs/widgets/gp_markup_parser.c
@@ -9,7 +9,7 @@
 #include <string.h>
 
 #include <core/gp_debug.h>
-#include <gp_markup_parser.h>
+#include <widgets/gp_markup_parser.h>
 
 static char *strcopy(char **buf, const char *str, size_t len)
 {

--- a/libs/widgets/gp_string.c
+++ b/libs/widgets/gp_string.c
@@ -11,7 +11,7 @@
 #include <stdarg.h>
 
 #include <core/gp_debug.h>
-#include <gp_string.h>
+#include <widgets/gp_string.h>
 
 size_t gp_string_arr_size(const char *strings[], unsigned int len)
 {

--- a/libs/widgets/gp_widget.c
+++ b/libs/widgets/gp_widget.c
@@ -9,8 +9,8 @@
 #include <string.h>
 #include <core/gp_debug.h>
 #include <core/gp_common.h>
-#include <gp_widget.h>
-#include <gp_widget_ops.h>
+#include <widgets/gp_widget.h>
+#include <widgets/gp_widget_ops.h>
 
 const char *gp_widget_class_name(enum gp_widget_class widget_class)
 {

--- a/libs/widgets/gp_widget_button.c
+++ b/libs/widgets/gp_widget_button.c
@@ -9,10 +9,10 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_widget_json.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_widget_json.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_checkbox.c
+++ b/libs/widgets/gp_widget_checkbox.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_choice.c
+++ b/libs/widgets/gp_widget_choice.c
@@ -8,8 +8,8 @@
 
 #include <string.h>
 #include <json-c/json.h>
-#include <gp_widgets.h>
-#include <gp_string.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_string.h>
 
 gp_widget *gp_widget_choice_from_json(unsigned int widget_type,
                                       json_object *json, gp_htable **uids)

--- a/libs/widgets/gp_widget_event.c
+++ b/libs/widgets/gp_widget_event.c
@@ -8,8 +8,8 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_event.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_event.h>
 
 static const char *ev_names[] = {
 	[GP_WIDGET_EVENT_NEW] = "new",

--- a/libs/widgets/gp_widget_frame.c
+++ b/libs/widgets/gp_widget_frame.c
@@ -11,10 +11,10 @@
 
 #include <core/gp_common.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_widget_json.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_widget_json.h>
 
 static unsigned int frame_w(const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_gfx.c
+++ b/libs/widgets/gp_widget_gfx.c
@@ -7,7 +7,7 @@
  */
 
 #include <string.h>
-#include <gp_widget_gfx.h>
+#include <widgets/gp_widget_gfx.h>
 
 static gp_size text_size(gp_size add_size, const gp_text_style *style,
                          const char *str, size_t len)

--- a/libs/widgets/gp_widget_grid.c
+++ b/libs/widgets/gp_widget_grid.c
@@ -14,9 +14,9 @@
 #include <core/gp_common.h>
 #include <utils/gp_vec.h>
 #include <utils/gp_matrix.h>
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_json.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_json.h>
 
 static gp_widget *widget_grid_grid_get(struct gp_widget_grid *grid,
                                        unsigned int col, unsigned int row)

--- a/libs/widgets/gp_widget_int.c
+++ b/libs/widgets/gp_widget_int.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static int check_val(int min, int max, int val)
 {

--- a/libs/widgets/gp_widget_label.c
+++ b/libs/widgets/gp_widget_label.c
@@ -11,9 +11,9 @@
 
 #include <utils/gp_vec_str.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_markup.c
+++ b/libs/widgets/gp_widget_markup.c
@@ -11,10 +11,10 @@
 
 #include <utils/gp_vec_str.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_markup_parser.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_markup_parser.h>
 
 static gp_text_style *get_font(const gp_widget_render_ctx *ctx, int attrs)
 {

--- a/libs/widgets/gp_widget_ops.c
+++ b/libs/widgets/gp_widget_ops.c
@@ -9,11 +9,11 @@
 #include <string.h>
 #include <core/gp_debug.h>
 #include <core/gp_common.h>
-#include <gp_widget.h>
-#include <gp_widget_event.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_widget_app.h>
+#include <widgets/gp_widget.h>
+#include <widgets/gp_widget_event.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_widget_app.h>
 
 extern struct gp_widget_ops gp_widget_grid_ops;
 extern struct gp_widget_ops gp_widget_tabs_ops;

--- a/libs/widgets/gp_widget_overlay.c
+++ b/libs/widgets/gp_widget_overlay.c
@@ -11,9 +11,9 @@
 
 #include <utils/gp_vec.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_pbar.c
+++ b/libs/widgets/gp_widget_pbar.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int pbar_min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_pixmap.c
+++ b/libs/widgets/gp_widget_pixmap.c
@@ -9,10 +9,10 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_widget_json.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_widget_json.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_radio_button.c
+++ b/libs/widgets/gp_widget_radio_button.c
@@ -9,10 +9,10 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_string.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_string.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_scroll_area.c
+++ b/libs/widgets/gp_widget_scroll_area.c
@@ -9,10 +9,10 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_widget_json.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_widget_json.h>
 
 static gp_size scroll_min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_spin_button.c
+++ b/libs/widgets/gp_widget_spin_button.c
@@ -9,10 +9,10 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
-#include <gp_string.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
+#include <widgets/gp_string.h>
 
 static unsigned int buttons_width(const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_stock.c
+++ b/libs/widgets/gp_widget_stock.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
+#include <widgets/gp_widgets.h>
 
 static unsigned int stock_min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_switch.c
+++ b/libs/widgets/gp_widget_switch.c
@@ -11,9 +11,9 @@
 
 #include <utils/gp_vec.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_table.c
+++ b/libs/widgets/gp_widget_table.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <json-c/json.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int header_min_w(gp_widget_table *tbl,
                                  const gp_widget_render_ctx *ctx,

--- a/libs/widgets/gp_widget_tabs.c
+++ b/libs/widgets/gp_widget_tabs.c
@@ -13,9 +13,9 @@
 #include <core/gp_common.h>
 #include <utils/gp_vec.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_string.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_string.h>
 
 static gp_size tab_w(gp_widget *self, const gp_widget_render_ctx *ctx,
                      unsigned int tab)

--- a/libs/widgets/gp_widget_tbox.c
+++ b/libs/widgets/gp_widget_tbox.c
@@ -11,9 +11,9 @@
 
 #include <utils/gp_vec_str.h>
 
-#include <gp_widgets.h>
-#include <gp_widget_ops.h>
-#include <gp_widget_render.h>
+#include <widgets/gp_widgets.h>
+#include <widgets/gp_widget_ops.h>
+#include <widgets/gp_widget_render.h>
 
 static unsigned int min_w(gp_widget *self, const gp_widget_render_ctx *ctx)
 {

--- a/libs/widgets/gp_widget_timer.c
+++ b/libs/widgets/gp_widget_timer.c
@@ -10,7 +10,7 @@
 #include <core/gp_common.h>
 #include <input/gp_timer.h>
 #include <input/gp_time_stamp.h>
-#include <gp_widget_timer.h>
+#include <widgets/gp_widget_timer.h>
 
 static gp_timer *temp_queue;
 static gp_timer **queue = &temp_queue;


### PR DESCRIPTION
When the widgets directory isn't in the include paths, the widget headers cannot be found. Being implicit about the widget headers' paths fixes this. It also aligns with the other gfxprim include paths too.