### PR TITLE
backends: sdl: Fix small spelling of "gp_sdl_lags"

### DIFF
--- a/include/backends/gp_sdl.h
+++ b/include/backends/gp_sdl.h
@@ -9,7 +9,7 @@
 #include <stdint.h>
 #include <backends/gp_backend.h>
 
-enum gp_sdl_lags {
+enum gp_sdl_flags {
 	GP_SDL_FULLSCREEN = 0x01,
 	GP_SDL_RESIZABLE  = 0x02,
 };


### PR DESCRIPTION
Small spelling mistake of the enum `gp_sdl_flags`.