### PR TITLE
backends: sdl: Fix includes to be relative from include

### DIFF
--- a/libs/backends/gp_input_driver_sdl.c
+++ b/libs/backends/gp_input_driver_sdl.c
@@ -11,7 +11,7 @@
 #include <core/gp_debug.h>
 
 #include <input/gp_event_queue.h>
-#include <backends/gp_input_driver_sdl.h>
+#include "gp_input_driver_sdl.h"
 
 /* SDL ascii mapped keys */
 static uint16_t keysym_table1[] = {

--- a/libs/backends/gp_input_driver_sdl.c
+++ b/libs/backends/gp_input_driver_sdl.c
@@ -11,7 +11,7 @@
 #include <core/gp_debug.h>
 
 #include <input/gp_event_queue.h>
-#include "gp_input_driver_sdl.h"
+#include <backends/gp_input_driver_sdl.h>
 
 /* SDL ascii mapped keys */
 static uint16_t keysym_table1[] = {

--- a/libs/backends/gp_sdl.c
+++ b/libs/backends/gp_sdl.c
@@ -13,7 +13,7 @@
 #ifdef HAVE_LIBSDL
 
 #include <input/gp_input.h>
-#include "gp_input_driver_sdl.h"
+#include <backends/gp_input_driver_sdl.h>
 #include <backends/gp_backend.h>
 #include <backends/gp_sdl.h>
 


### PR DESCRIPTION
When compiling with SDL, the includes for the backend did not provide relative includes from the include directory, resulting in not found when the backends directory wasn't added to the include path. This cleans that up for the includes to be relative from the include directory itself.