### PR TITLE
tests and docs: Skip Widgets if JSON-C isn't available

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,4 +1,9 @@
 TOPDIR=..
 -include $(TOPDIR)/config.gen.mk
-SUBDIRS=grinder spiv particle ttf2img c_simple bogoman widgets
+SUBDIRS=grinder spiv particle ttf2img c_simple bogoman
+
+ifeq ($(HAVE_JSON-C),yes)
+SUBDIRS+=widgets
+endif
+
 include $(TOPDIR)/post.mk

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,11 @@
 TOPDIR=..
 include $(TOPDIR)/pre.mk
 
-SUBDIRS=core framework loaders gfx filters input widgets utils
+SUBDIRS=core framework loaders gfx filters input utils
+
+ifeq ($(HAVE_JSON-C),yes)
+SUBDIRS+=widgets
+endif
 
 loaders: framework
 gfx: framework


### PR DESCRIPTION
When JSON-C isn't available, it's assumed that the widgets should be skipped. This adds that condition to the tests and the docs.