### PR TITLE
widgets: Restore widgets being built

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,5 +1,5 @@
 TOPDIR=..
 -include $(TOPDIR)/config.gen.mk
-SUBDIRS=grinder spiv particle ttf2img c_simple bogoman
+SUBDIRS=grinder spiv particle ttf2img c_simple bogoman widgets
 
 include $(TOPDIR)/post.mk

--- a/libs/Makefile
+++ b/libs/Makefile
@@ -1,5 +1,5 @@
 TOPDIR=..
-SUBDIRS=core utils gfx text loaders filters input backends grabbers
+SUBDIRS=core utils gfx text loaders filters input backends grabbers widgets
 
 include $(TOPDIR)/config.mk
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 TOPDIR=..
 include $(TOPDIR)/pre.mk
 
-SUBDIRS=core framework loaders gfx filters input utils
+SUBDIRS=core framework loaders gfx filters input utils widgets
 
 loaders: framework
 gfx: framework


### PR DESCRIPTION
Following the commit at https://github.com/gfxprim/gfxprim/commit/23d72e1af5fc0659db9f5e61d814012b86a02d1b , we should likely have the widget SUBDIRS in the builds :wink: 