### PR TITLE
backend: Segfault guard on gp_backend_poll()

### DIFF
--- a/libs/backends/gp_backend.c
+++ b/libs/backends/gp_backend.c
@@ -172,6 +172,9 @@ void gp_backend_task_rem(gp_backend *self, gp_task *task)
 
 void gp_backend_poll(gp_backend *self)
 {
+	if (!self)
+		return;
+
 	self->poll(self);
 
 	if (self->timers)


### PR DESCRIPTION
This change protects against a segault when passing a null backend to gp_backend_poll().