### PR TITLE
backend: Protect segfault gp_backend_flip()

### DIFF
--- a/include/backends/gp_backend.h
+++ b/include/backends/gp_backend.h
@@ -144,8 +144,9 @@ struct gp_backend {
 
 static inline void gp_backend_flip(gp_backend *self)
 {
-	if (self->flip)
-		self->flip(self);
+	if (self)
+		if (self->flip)
+			self->flip(self);
 }
 
 void gp_backend_update_rect_xyxy(gp_backend *self,


### PR DESCRIPTION
When calling gp_backend_flip() when the backend isn't set will result in a segfault. This fixed that.